### PR TITLE
Fix rubocop workflow properly for push trigger

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,6 +11,12 @@ on: [push, pull_request]
 jobs:
   rubocop:
     runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
     strategy:
       fail-fast: false
 
@@ -51,7 +57,7 @@ jobs:
         bundle exec rubocop --require code_scanning --format progress --format CodeScanning::SarifFormatter -o rubocop.sarif
 
     - name: Upload Sarif output
-      if: (success() || failure()) && (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/dependabot/'))
+      if: success() || failure()
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: rubocop.sarif


### PR DESCRIPTION
Closes #6

Instead of not running on the push trigger for Dependabot branches, which is not fully effective because it still fails on main when a merge is done by Dependabot due to `@dependabot merge` or similar command, this just specifies the required permissions in the workflow file, as is done e.g. in automatically generated CodeQL workflow files and as suggested in #6.

I tested this in https://github.com/EliahKagan/hello-world. See:

- https://github.com/EliahKagan/hello-world/pull/14, including https://github.com/EliahKagan/hello-world/commit/d565b8475c7bda154aec5c2e1b46a3a12daed70d
- https://github.com/EliahKagan/hello-world/pull/15
- https://github.com/EliahKagan/hello-world/pull/16